### PR TITLE
Add developer documentation using Sphinx

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ quadrex/
 └── run.py             # Application entry point
 ```
 
-**## Installation**
+## Installation
 
 1. Clone the repository:
 
@@ -127,15 +127,16 @@ quadrex/
 
     The application will be available at `http://localhost:5000`
 
-**## Development**
+## Development
 
-**### Database Migrations**
+### Database Migrations
 
 To create a new migration after model changes:
 
 ```bash
 uv run flask db migrate -m "Description of changes"
 uv run flask db upgrade
+```
 
 ### Running Tests
 
@@ -150,6 +151,24 @@ This project follows PEP 8 style guide. To check code style:
 ```bash
 uv run ruff check
 ```
+
+### Building Documentation
+
+To build the Sphinx documentation:
+
+1. Navigate to the `docs` directory:
+
+    ```bash
+    cd docs
+    ```
+
+2. Build the HTML documentation:
+
+    ```bash
+    uv run make html
+    ```
+
+    The documentation will be available in the `_build/html` directory.
 
 ## Security
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,51 @@
+.. _api:
+
+API Documentation
+=================
+
+This section provides the API reference for all modules in the Quadrex project.
+
+.. automodule:: app
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. automodule:: app.auth
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. automodule:: app.categories
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. automodule:: app.transactions
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. automodule:: app.main
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. automodule:: app.models
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. automodule:: app.cli
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. automodule:: config
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. automodule:: run
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,23 @@
+# Configuration file for the Sphinx documentation builder.
+
+# -- Project information -----------------------------------------------------
+
+project = 'Quadrex'
+author = 'Vikrant Rathore'
+release = '0.1.0'
+
+# -- General configuration ---------------------------------------------------
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.viewcode',
+]
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+# -- Options for HTML output -------------------------------------------------
+
+html_theme = 'alabaster'
+html_static_path = ['_static']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,22 @@
+.. Quadrex documentation master file, created by
+   sphinx-quickstart on Thu Sep 30 00:00:00 2021.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to Quadrex's documentation!
+===================================
+
+Introduction
+------------
+
+Quadrex is a modern, user-friendly web application for personal financial management built with Flask and HTMX. This documentation provides an overview of the system, including its architecture, modules, and API.
+
+Contents
+--------
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Table of Contents
+
+   modules
+   api

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,0 +1,20 @@
+.. _modules:
+
+Modules
+=======
+
+This section provides an overview of the modules in the Quadrex project.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Modules
+
+   app
+   app.auth
+   app.categories
+   app.transactions
+   app.main
+   app.models
+   app.cli
+   config
+   run


### PR DESCRIPTION
Add developer documentation using Sphinx.

* **Add Sphinx Configuration**: Create `docs/conf.py` with project information, extensions, and HTML output options.
* **Add Documentation Index**: Create `docs/index.rst` with an introduction and table of contents.
* **Add Module Documentation**: Create `docs/modules.rst` listing all project modules.
* **Add API Documentation**: Create `docs/api.rst` with API references for all modules.
* **Update README**: Include instructions for building the documentation and remove the line to install Sphinx.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/eonseed/quadrex/pull/1?shareId=c736b83b-d5dc-4c0a-bfc9-f7d0cd1f23cc).